### PR TITLE
Remove unused accessors from protocols

### DIFF
--- a/Youth/Classes/Presentation Layer/Modules/Photos/Router/PhotosRouter.swift
+++ b/Youth/Classes/Presentation Layer/Modules/Photos/Router/PhotosRouter.swift
@@ -13,9 +13,9 @@ final class PhotosRouter: PhotosRouterInput {
     
     weak var viewController: UIViewController?
     
-    var photosCollectionSubModuleOnParentModuleReady: (() -> ())?
-    var photosCollectionSubModuleOnLayoutChange: ((YouthCollectionLayout) -> ())?
-    var photosCollectionSubModuleOnUsageChange: ((PhotosCollectionUsage) -> ())?
+    private(set) var photosCollectionSubModuleOnParentModuleReady: (() -> ())?
+    private(set) var photosCollectionSubModuleOnLayoutChange: ((YouthCollectionLayout) -> ())?
+    private(set) var photosCollectionSubModuleOnUsageChange: ((PhotosCollectionUsage) -> ())?
     
     func closeModule() {
         viewController?.dismiss(animated: true)

--- a/Youth/Classes/Presentation Layer/Modules/Photos/Router/Router Input/PhotosRouterInput.swift
+++ b/Youth/Classes/Presentation Layer/Modules/Photos/Router/Router Input/PhotosRouterInput.swift
@@ -10,9 +10,9 @@ import UIKit
 
 protocol PhotosRouterInput: class {
     
-    var photosCollectionSubModuleOnParentModuleReady: (() -> ())? { get set }
-    var photosCollectionSubModuleOnLayoutChange: ((YouthCollectionLayout) -> ())? { get set }
-    var photosCollectionSubModuleOnUsageChange: ((PhotosCollectionUsage) -> ())? { get set }
+    var photosCollectionSubModuleOnParentModuleReady: (() -> ())? { get }
+    var photosCollectionSubModuleOnLayoutChange: ((YouthCollectionLayout) -> ())? { get }
+    var photosCollectionSubModuleOnUsageChange: ((PhotosCollectionUsage) -> ())? { get }
     
     func closeModule()
     

--- a/Youth/Classes/Presentation Layer/Modules/Search Photos/Router/Router Input/SearchPhotosRouterInput.swift
+++ b/Youth/Classes/Presentation Layer/Modules/Search Photos/Router/Router Input/SearchPhotosRouterInput.swift
@@ -10,9 +10,9 @@ import UIKit
 
 protocol SearchPhotosRouterInput: class {
     
-    var photosCollectionSubModuleOnParentModuleReady: (() -> ())? { get set }
-    var photosCollectionSubModuleOnLayoutChange: ((YouthCollectionLayout) -> ())? { get set }
-    var photosCollectionSubModuleOnUsageChange: ((PhotosCollectionUsage) -> ())? { get set }
+    var photosCollectionSubModuleOnParentModuleReady: (() -> ())? { get }
+    var photosCollectionSubModuleOnLayoutChange: ((YouthCollectionLayout) -> ())? { get }
+    var photosCollectionSubModuleOnUsageChange: ((PhotosCollectionUsage) -> ())? { get }
     
     func closeModule()
     

--- a/Youth/Classes/Presentation Layer/Modules/Search Photos/Router/SearchPhotosRouter.swift
+++ b/Youth/Classes/Presentation Layer/Modules/Search Photos/Router/SearchPhotosRouter.swift
@@ -12,9 +12,9 @@ final class SearchPhotosRouter: SearchPhotosRouterInput {
     
     weak var viewController: UIViewController?
     
-    var photosCollectionSubModuleOnParentModuleReady: (() -> ())?
-    var photosCollectionSubModuleOnLayoutChange: ((YouthCollectionLayout) -> ())?
-    var photosCollectionSubModuleOnUsageChange: ((PhotosCollectionUsage) -> ())?
+    private(set) var photosCollectionSubModuleOnParentModuleReady: (() -> ())?
+    private(set) var photosCollectionSubModuleOnLayoutChange: ((YouthCollectionLayout) -> ())?
+    private(set) var photosCollectionSubModuleOnUsageChange: ((PhotosCollectionUsage) -> ())?
     
     func closeModule() {
         viewController?.dismiss(animated: true)

--- a/Youth/Classes/Presentation Layer/Modules/User Profile/Router/Router Input/UserProfileRouterInput.swift
+++ b/Youth/Classes/Presentation Layer/Modules/User Profile/Router/Router Input/UserProfileRouterInput.swift
@@ -10,7 +10,7 @@ import UIKit
 
 protocol UserProfileRouterInput: class {
     
-    var photosCollectionSubModuleOnParentModuleReady: (() -> ())? { get set }
+    var photosCollectionSubModuleOnParentModuleReady: (() -> ())? { get }
     
     func closeModule()
     

--- a/Youth/Classes/Presentation Layer/Modules/User Profile/Router/UserProfileRouter.swift
+++ b/Youth/Classes/Presentation Layer/Modules/User Profile/Router/UserProfileRouter.swift
@@ -10,7 +10,7 @@ import UIKit
 
 final class UserProfileRouter: UserProfileRouterInput {
     
-    var photosCollectionSubModuleOnParentModuleReady: (() -> ())?
+    private(set) var photosCollectionSubModuleOnParentModuleReady: (() -> ())?
     
     weak var viewController: UIViewController?
     


### PR DESCRIPTION
Reviewer: cristian.lupu

### What has been done?
1. Removed unused accessors from protocols, like *RouterInput.

### How to test?
1. Run unit tests.

### Checklist
<!-- Please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
- [x] I've run tests before opening PR
- [x] I haven't introduced new warnings